### PR TITLE
Add more template options

### DIFF
--- a/capturing.js
+++ b/capturing.js
@@ -1,27 +1,51 @@
 var capture = function(config){
 
-    var replace_all = function(str, find, replace) {
-        return str.replace(new RegExp(find, 'g'), replace);
-    };
-    var esc = function (text) {
-        return replace_all(replace_all(replace_all(encodeURIComponent(text),
-                                                   "[(]",
-                                                   escape("(")),
-                                       "[)]",
-                                       escape(")")),
-                           "[']",
-                           escape("'"));
-    };
+    /**
+     * Escape all instances of a character @p char
+     */
+    String.prototype.esc = function(char) {
+        var rx = new RegExp("[" + char + "]", 'g');
+        return this.replace(rx, escape(char));
+    }
 
-    var uri = 'org-protocol://capture:/';
+    /**
+     * Escape all parentheses and single quotes in a string
+     */
+    var esc_parentheses_quote = function (text) {
+        return text.esc("(").esc(")").esc("'");
+    }
 
-    uri += config.template;
+    /**
+     * Construct a URI for the appropriate the org-capture template.
+     * TEMPLATE corresponds to org-capture-template hotkey.
+     *
+     * The general format is:
+     * org-protocol://capture://TEMPLATE/URL/TITLE/TEXT
+     */
+    var uri = 'org-protocol://capture://';
 
-    uri += '/' + encodeURIComponent(location.href)
-        +  '/' + encodeURIComponent(document.title);
+    // Only include text field if there is a selection in the webpage
+    var text = window.getSelection().toString();
+    if (text != "") { text = '/' + esc_parentheses_quote(text);};
 
-    var selection = window.getSelection().toString();
-    if (selection != "") { uri += '/' +	esc(selection); };
+    switch (config.template) {
+    case "c":
+        uri = uri + config.template + '/'
+            + encodeURIComponent(window.location.href) + '/'
+            + encodeURIComponent(document.title) 
+            + text;
+        break;
+    case "l":
+        uri = uri + config.template + '/'
+            + encodeURIComponent(location.href) + '/'
+            + encodeURIComponent(document.title);
+        break;
+    case "o":
+        uri = uri + encodeURIComponent(window.location.href) + '/'
+            + encodeURIComponent(document.title)
+            + text;
+        break;
+    }
 
     console.log("Preview of org-protocol URI: ", uri);
 

--- a/main.js
+++ b/main.js
@@ -1,13 +1,22 @@
+// Translate the keyboard shortcuts in manifest.json
+
 chrome.commands.onCommand.addListener(function(command) {
     var config = {};
-    if(command == "link")
-    {
+    switch(command) {
+    case "link":
         config.template = "l";
-    }
-    else if (command == "query")
-    {
+        break;
+    case "capture":
+        config.template = "c";
+        break;
+    case "other":
+        config.template = "o";
+        break;
+    case "query":
         config.template = "q";
+        break;
     }
+
     chrome.tabs.executeScript(
         {code: 'var config = ' + JSON.stringify(config)},
         function () {

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,11 @@
         "link": {
             "suggested_key": { "default": "Ctrl+Shift+L" },
             "description": "Capture the link, if there was a selection, send that too"
+        },
+
+        "capture": {
+            "suggested_key": { "default": "Ctrl+Shift+C" },
+            "description": "Capture the selected text"
         }
     },
 

--- a/popup.html
+++ b/popup.html
@@ -8,7 +8,9 @@
     <h1>Org-Capture</h1>
     <h2>Select your template: </h2>
     <select id="template" name="template-select">
-        <option value="l">Link</option>
+        <option value="c">Link and Text</option>
+        <option value="l">Link Only</option>
+        <option value="o">Select option in emacs...</option>
     </select>
     <button id="submit">Capture!</button>
   </body>


### PR DESCRIPTION
I wanted to save this until I wrote a customization menu, but I realized that it might be better to just submit these changes separately, and leave the menu for when I know I have time for it. This gives three options for templates, link-only, which looks for template 'l' (this was what I asked about on Reddit), link+text, which requests template 'c', maintaining the same behavior as before, and 'select option in emacs,' which gives no capture template, and lets the user select the template after submitting the option.
