### PR TITLE
More robust opening of uri

### DIFF
--- a/capturing.js
+++ b/capturing.js
@@ -49,7 +49,7 @@ var capture = function(config){
 
     console.log("Preview of org-protocol URI: ", uri);
 
-    return uri;
+    location.href = uri;
 };
 
 capture(config);

--- a/main.js
+++ b/main.js
@@ -22,9 +22,8 @@ chrome.commands.onCommand.addListener(function(command) {
         function () {
             chrome.tabs.executeScript(
                 {file: 'capturing.js'},
-                (function (url_array) {
-                    chrome.tabs.update({url : url_array[0]});
-                }))
+                (function (url_array) {}
+                ))
         }
     );
 });

--- a/popup.js
+++ b/popup.js
@@ -8,9 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
             function () {
                 chrome.tabs.executeScript(
                     {file: 'capturing.js'},
-                    (function (url_array) {
-                        chrome.tabs.update({url : url_array[0]});
-                    })
+                    (function (url_array) {})
                 )
             });
     }, false);


### PR DESCRIPTION
This is an attempt to fix issue #3: the issue seems to be that chrome.tabs.update does not always pass the uri to the OS.  Stealing the strategy of [sprig/org-capture-extension](https://github.com/sprig/org-capture-extension), I set location.href  instead.

This completely fixes #3 for me.  However, I have only tested this under GNU/Linux (LMDE 2) since I have no access to windows or MacOS boxen.

Please forgive me if I have made some glaring mistake: this is my first ever pull request!